### PR TITLE
Add a) request queuing b) updating lock status from requests

### DIFF
--- a/pynuki/pynuki.py
+++ b/pynuki/pynuki.py
@@ -131,7 +131,7 @@ class NukiLock(object):
 
 
 class NukiBridge(object):
-    def __init__(self, hostname, token, port=8080, timeout=REQUESTS_TIMEOUT, should_queue=False):
+    def __init__(self, hostname, token, port=8080, timeout=REQUESTS_TIMEOUT, should_queue=True):
         self.hostname = hostname
         self.token = token
         self.port = port
@@ -140,7 +140,7 @@ class NukiBridge(object):
         self.should_queue = should_queue
 
     @staticmethod
-    def __make_request(url,token, endpoint, requests_timeout, params=None, should_queue=False):
+    def __make_request(url,token, endpoint, requests_timeout, should_queue, params=None):
         if should_queue:
            RQ_LOCK.acquire()
            time.sleep(REQUEST_GAP_SECONDS)
@@ -164,7 +164,7 @@ class NukiBridge(object):
            return return_result
 
     def __rq(self, endpoint, params=None):
-        return self.__make_request(self.__api_url, self.token, endpoint, self.requests_timeout, params, self.should_queue)
+        return self.__make_request(self.__api_url, self.token, endpoint, self.requests_timeout, self.should_queue, params)
 
     def auth(self):
         result = self.__rq('auth')
@@ -179,7 +179,7 @@ class NukiBridge(object):
     def lock_state(self, nuki_id):
       return self.__rq('lockState', {'nukiId': nuki_id})
 
-    def lock_action(self, nuki_id, action, block=False):
+    def lock_action(self, nuki_id, action, block=True):
         params = {
             'nukiId': nuki_id,
             'action': action,
@@ -244,23 +244,23 @@ class NukiBridge(object):
             locks.append(NukiLock(self, data))
         return locks
 
-    def lock(self, nuki_id, block=False):
+    def lock(self, nuki_id, block=True):
         return self.lock_action(
             nuki_id, action=LOCK_ACTIONS['LOCK'], block=block
         )
 
-    def unlock(self, nuki_id, block=False):
+    def unlock(self, nuki_id, block=True):
         return self.lock_action(
             nuki_id, action=LOCK_ACTIONS['UNLOCK'], block=block
         )
 
-    def lock_n_go(self, nuki_id, unlatch=False, block=False):
+    def lock_n_go(self, nuki_id, unlatch=False, block=True):
         action = LOCK_ACTIONS['LOCK_N_GO']
         if unlatch:
             action = LOCK_ACTIONS['LOCK_N_GO_WITH_UNLATCH']
         return self.lock_action(nuki_id, action=action, block=block)
 
-    def unlatch(self, nuki_id, block=False):
+    def unlatch(self, nuki_id, block=True):
         return self.lock_action(
             nuki_id, action=LOCK_ACTIONS['UNLATCH'], block=block
         )

--- a/pynuki/pynuki.py
+++ b/pynuki/pynuki.py
@@ -121,9 +121,6 @@ class NukiLock(object):
               self._json.update({k: v for k, v in data.items() if k != 'success'})
         else:
             data = [l for l in self._bridge.locks if l.nuki_id == self.nuki_id]
-            if data is None or not data['success']:
-               logger.warning('Failed to update the state of lock {}'.format(self.nuki_id))
-               raise ValueError('Update not completed')
             assert data, (
                    'Failed to update data for lock. '
                    'Nuki ID {} volatized.'.format(self.nuki_id))
@@ -154,9 +151,11 @@ class NukiBridge(object):
              get_params.update(params)
            return_result = None
            try:
+             logger.debug('Nuki request {} {} '.format(url,get_params))
              result = requests.get(url, params=get_params, timeout=requests_timeout)
              result.raise_for_status()
              return_result = result.json()
+             logger.debug('Nuki response {} '.format(return_result))
            except Exception as e:
              logger.warning('Nuki bridge request failed {}'.format(e))
         finally:


### PR DESCRIPTION
Hi,

Thank you for your work on this.

I have a new nuki v2 lock and bridge and experienced a lot of issues, many described here: https://developer.nuki.io/t/random-http-503-unavailable/909

This is as per current state of firmware and bridge, September 2019.
Issues:
  a) bridge can only support one connection at a time
  b) bridge enters uncommunicative state if a request received within 0.5 of another
  c) bridge gets overwhelmed by several requests

I've had much better success with these fixes. I've tried to keep existing functionality where applicable. Some corresponding changes will be posted for homeassistant, i..e. make sure we use blocking requests, maintain state where possible.

Also, complete python newbie here, happy to take advice 

Thanks,

Alex

