### PR TITLE
Fix list(self, device_type=None) so that it always returns the wanted device_type

### DIFF
--- a/pynuki/bridge.py
+++ b/pynuki/bridge.py
@@ -125,7 +125,7 @@ class NukiBridge(object):
 
     def list(self, device_type=None):
         data = self.__rq("list")
-        if device_type:
+        if device_type != None:
             return [x for x in data if x.get("deviceType") == device_type]
         return data
 


### PR DESCRIPTION
When called with device_type=0 (lock) it is handled like called with missing device_type. This leads to return of all devices (means ignoring the device_type)