### PR TITLE
Add device type to opener methods; add is_rto_activated property

### DIFF
--- a/pynuki/opener.py
+++ b/pynuki/opener.py
@@ -10,6 +10,7 @@ class NukiOpener(NukiDevice):
         return self._bridge.lock_action(
             nuki_id=self.nuki_id,
             action=const.ACTION_OPENER_ACTIVATE_RTO,
+            device_type=const.DEVICE_TYPE_OPENER,
             block=block,
         )
 
@@ -17,6 +18,7 @@ class NukiOpener(NukiDevice):
         return self._bridge.lock_action(
             nuki_id=self.nuki_id,
             action=const.ACTION_OPENER_DEACTIVATE_RTO,
+            device_type=const.DEVICE_TYPE_OPENER,
             block=block,
         )
 
@@ -24,6 +26,7 @@ class NukiOpener(NukiDevice):
         return self._bridge.lock_action(
             nuki_id=self.nuki_id,
             action=const.ACTION_OPENER_ELECTRIC_STRIKE_ACTUATION,
+            device_type=const.DEVICE_TYPE_OPENER,
             block=block,
         )
 
@@ -31,6 +34,7 @@ class NukiOpener(NukiDevice):
         return self._bridge.lock_action(
             nuki_id=self.nuki_id,
             action=const.ACTION_OPENER_ACTIVATE_CONTINUOUS,
+            device_type=const.DEVICE_TYPE_OPENER,
             block=block,
         )
 
@@ -38,5 +42,6 @@ class NukiOpener(NukiDevice):
         return self._bridge.lock_action(
             nuki_id=self.nuki_id,
             action=const.ACTION_OPENER_DEACTIVATE_CONTINUOUS,
+            device_type=const.DEVICE_TYPE_OPENER,
             block=block,
         )

--- a/pynuki/opener.py
+++ b/pynuki/opener.py
@@ -6,6 +6,10 @@ from .utils import logger
 
 
 class NukiOpener(NukiDevice):
+    @property
+    def is_rto_activated(self):
+        return self.state == const.STATE_OPENER_RTO_ACTIVE
+
     def activate_rto(self, block=False):
         return self._bridge.lock_action(
             nuki_id=self.nuki_id,


### PR DESCRIPTION
The opener methods don't work without the device type included as a parameter. 