### PR TITLE
Add method to update state from a callback

### DIFF
--- a/pynuki/device.py
+++ b/pynuki/device.py
@@ -99,7 +99,9 @@ class NukiDevice(object):
         Update the state of the Nuki device from a callback
         :param json: Callback JSON body
         """
-        assert json.get("nukiId") == self.nuki_id, "Failed to update data from callback. Wrong Nuki ID."
+        assert (
+            json.get("nukiId") == self.nuki_id
+        ), "Failed to update data from callback. Wrong Nuki ID."
         self._json.update(json)
 
     def __repr__(self):

--- a/pynuki/device.py
+++ b/pynuki/device.py
@@ -94,5 +94,13 @@ class NukiDevice(object):
             )
             self._json.update(data[0]._json)
 
+    def update_from_callback(self, json):
+        """
+        Update the state of the Nuki device from a callback
+        :param json: Callback JSON body
+        """
+        assert json.get("nukiId") == self.nuki_id, "Failed to update data from callback. Wrong Nuki ID."
+        self._json.update(json)
+
     def __repr__(self):
         return f"<{self.__class__.__name__}: {self._json}>"


### PR DESCRIPTION
Hi,

I've added a method to update the JSON state of a `NukiDevice` from an external caller (e.g. a callback/webhook).

For context: I'm working on switching the Home Assistant Nuki component from polling to Bridge callbacks.