### PR TITLE
fix(bridge): catch KeyError when device gets unavailable

### DIFF
--- a/pynuki/bridge.py
+++ b/pynuki/bridge.py
@@ -204,11 +204,14 @@ class NukiBridge(object):
             }
             # state_data holds the last known state of the lock
             # eg: {'batteryCritical': False, 'state': 1, 'stateName': 'locked'}
-            state_data = {
-                k: v
-                for k, v in dev["lastKnownState"].items()
-                if k not in ["timestamp"]
-            }
+            try:
+                state_data = {
+                    k: v
+                    for k, v in dev["lastKnownState"].items()
+                    if k not in ["timestamp"]
+                }
+            except KeyError:
+                state_data = {}
 
             # Merge lock_data and state_data
             data = {**device_data, **state_data}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pynuki"
-version = "1.4.1"
+version = "1.4.2"
 description = "Python bindings for nuki.io bridges"
 authors = ["Philipp Schmitt <philipp@schmitt.co>"]
 license = "GPL-3.0-only"


### PR DESCRIPTION
When a device gets unavailable (i.e. when the battery runs out) it throws a KeyError. Catching it results in still getting a response from the other devices.