### PR TITLE
chore(bridge-api): update to 1.13.1

### DIFF
--- a/pynuki/bridge.py
+++ b/pynuki/bridge.py
@@ -216,6 +216,10 @@ class NukiBridge(object):
             dev_type = device_data.get("deviceType")
             if dev_type == const.DEVICE_TYPE_LOCK:
                 dev = NukiLock(self, data)
+            elif dev_type == const.DEVICE_TYPE_SMARTDOOR:
+                dev = NukiLock(self, data)
+            elif dev_type == const.DEVICE_TYPE_SMARTLOCK3:
+                dev = NukiLock(self, data)
             elif dev_type == const.DEVICE_TYPE_OPENER:
                 dev = NukiOpener(self, data)
             else:

--- a/pynuki/constants.py
+++ b/pynuki/constants.py
@@ -20,6 +20,8 @@ BRIDGE_TYPE_SW = 2
 # https://developer.nuki.io/page/nuki-bridge-http-api-1-10/4#heading--device-types
 DEVICE_TYPE_LOCK = 0
 DEVICE_TYPE_OPENER = 2
+DEVICE_TYPE_SMARTDOOR = 3
+DEVICE_TYPE_SMARTLOCK3 = 4
 
 # https://developer.nuki.io/page/nuki-bridge-http-api-1-10/4#heading--modes
 MODE_LOCK_DOOR = 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pynuki"
-version = "1.4.1"
+version = "1.5.0"
 description = "Python bindings for nuki.io bridges"
 authors = ["Philipp Schmitt <philipp@schmitt.co>"]
 license = "GPL-3.0-only"


### PR DESCRIPTION
This updates the API to 1.13.1 to include the new SmartDoor & SmartLock3
Ref: https://github.com/pschmitt/pynuki/issues/74

It handles both new devices just as `NukiLock`. Since I don't have any of those two devices I cannot test this change. 