### PR TITLE
fix(bridge): return all lock types in bridge.locks

### DIFF
--- a/pynuki/bridge.py
+++ b/pynuki/bridge.py
@@ -238,7 +238,11 @@ class NukiBridge(object):
 
     @property
     def locks(self):
-        return self._get_devices(device_type=const.DEVICE_TYPE_LOCK)
+        locks = []
+        for device in self._get_devices():
+            if isinstance(device, NukiLock):
+                locks.append(device)
+        return locks
 
     @property
     def openers(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pynuki"
-version = "1.5.1"
+version = "1.5.2"
 description = "Python bindings for nuki.io bridges"
 authors = ["Philipp Schmitt <philipp@schmitt.co>"]
 license = "GPL-3.0-only"


### PR DESCRIPTION
`bridge.locks` just returned Locks v1 & v2. Since Locks V3 & the SmartDoor have new deviceTypes they were not included. This should fix this behaviour.

Not sure if it's the best way to do this, feel free to change it :)