### PR TITLE
Adding correct product names

### DIFF
--- a/pynuki/device.py
+++ b/pynuki/device.py
@@ -64,20 +64,6 @@ class NukiDevice(object):
         return "UNKNOWN"
 
     @property
-    def device_model_str(self):
-       dev = self.device_type
-        if dev == const.DEVICE_TYPE_LOCK:
-            return "Nuki Smart Lock 1.0/2.0"
-        elif dev == const.DEVICE_TYPE_OPENER:
-            return "Nuki Opener"
-        elif dev == const.DEVICE_TYPE_SMARTDOOR:
-            return "Nuki Smart Door"
-        elif dev == const.DEVICE_TYPE_SMARTLOCK3:
-            return "Nuki Smart Lock 3.0 (Pro)"
-        logger.error(f"Unknown device type: {dev}")
-        return "UNKNOWN"
-
-    @property
     def mode(self):
         return self._json.get("mode")
 

--- a/pynuki/device.py
+++ b/pynuki/device.py
@@ -45,13 +45,12 @@ class NukiDevice(object):
             return "lock"
         elif dev == const.DEVICE_TYPE_OPENER:
             return "opener"
-
         logger.error(f"Unknown device type: {dev}")
         return "UNKNOWN"
 
     @property
     def device_model_str(self):
-       dev = self.device_type
+        dev = self.device_type
         if dev == const.DEVICE_TYPE_LOCK:
             return "Nuki Smart Lock 1.0/2.0"
         elif dev == const.DEVICE_TYPE_OPENER:

--- a/pynuki/device.py
+++ b/pynuki/device.py
@@ -49,6 +49,20 @@ class NukiDevice(object):
         return "UNKNOWN"
 
     @property
+    def device_model_str(self):
+       dev = self.device_type
+        if dev == const.DEVICE_TYPE_LOCK:
+            return "Nuki Smart Lock 1.0/2.0"
+        elif dev == const.DEVICE_TYPE_OPENER:
+            return "Nuki Opener"
+        elif dev == const.DEVICE_TYPE_SMARTDOOR:
+            return "Nuki Smart Door"
+        elif dev == const.DEVICE_TYPE_SMARTLOCK3:
+            return "Nuki Smart Lock 3.0 (Pro)"
+        logger.error(f"Unknown device type: {dev}")
+        return "UNKNOWN"
+
+    @property
     def mode(self):
         return self._json.get("mode")
 


### PR DESCRIPTION
Changed the `device_type_str` method so it returns the actual name of the Nuki product.
Not sure if I should've done that here, or if it's better to create a `device_model_str()` method.