### PR TITLE
Add more state checks for the lock

### DIFF
--- a/pynuki/lock.py
+++ b/pynuki/lock.py
@@ -8,7 +8,7 @@ class NukiLock(NukiDevice):
     @property
     def is_locked(self):
         return self.state == const.STATE_LOCK_LOCKED
-    
+
     @property
     def is_unlocked(self):
         return self.state == const.STATE_LOCK_UNLOCKED
@@ -24,7 +24,7 @@ class NukiLock(NukiDevice):
     @property
     def is_jammed(self):
         return self.state == const.STATE_LOCK_MOTOR_BLOCKED
-        
+
     @property
     def is_door_sensor_activated(self):
         # Nuki v1 locks don't have a door sensor, therefore the

--- a/pynuki/lock.py
+++ b/pynuki/lock.py
@@ -8,7 +8,23 @@ class NukiLock(NukiDevice):
     @property
     def is_locked(self):
         return self.state == const.STATE_LOCK_LOCKED
+    
+    @property
+    def is_unlocked(self):
+        return self.state == const.STATE_LOCK_UNLOCKED
 
+    @property
+    def is_locking(self):
+        return self.state == const.STATE_LOCK_LOCKING
+
+    @property
+    def is_unlocking(self):
+        return self.state == const.STATE_LOCK_UNLOCKING
+
+    @property
+    def is_jammed(self):
+        return self.state == const.STATE_LOCK_MOTOR_BLOCKED
+        
     @property
     def is_door_sensor_activated(self):
         # Nuki v1 locks don't have a door sensor, therefore the


### PR DESCRIPTION
Useful for triggering actions on other states than Locked and NOT Locked (like alerts for jammed or lights for actually Unlocked, as opposed to turning on lights for "Locking/Unlocking state" - ie. Not Locked)

Context: HomeAssistant Lock entity already has these states; while this could be implemented into the Nuki Lock integration of HomeAssistant without this PR, it would be better to start here ... 